### PR TITLE
add flake.lock, clean up flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784842214,
+        "narHash": "sha256-5RtCAzg/n1n2Yp0mtDiZzZFJzvqR4jHleWeqD7b5G14=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "91cc1fdf6831e29b6c98768e721a72241f3d0797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,20 @@
 {
   description = "A sakura tree with falling petals for your terminal (cmatrix-style)";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forAllSystems = f:
-        nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in
     {
-      packages = forAllSystems (pkgs: rec {
+      packages = forAllSystems (pkgs: {
         csakura = pkgs.stdenv.mkDerivation {
           pname = "csakura";
           version = "2.0.0";
@@ -20,7 +24,7 @@
           nativeBuildInputs = [ pkgs.pkg-config ];
           buildInputs = [ pkgs.ncurses ];
 
-          makeFlags = [ "PREFIX=${placeholder "out"}" "CC=cc" ];
+          makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
           meta = with pkgs.lib; {
             description = "A sakura tree with falling petals for your terminal (cmatrix-style)";
@@ -31,15 +35,7 @@
           };
         };
 
-        default = csakura;
-      });
-
-      apps = forAllSystems (pkgs: rec {
-        csakura = {
-          type = "app";
-          program = "${self.packages.${pkgs.system}.csakura}/bin/csakura";
-        };
-        default = csakura;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.csakura;
       });
 
       devShells = forAllSystems (pkgs: {


### PR DESCRIPTION
thanks for adding a flake.nix!

i've made some changes here that should allow the flake to be used by others trying to run your software (eg. with `nix run github:realstrawhat/csakura`)

# changes made
- add lockfile (`flake.lock`) to ensure dependencies remain pinned, and to prevent requiring adding `--no-write-lock-file` to the `nix run` command

## changes to `flake.nix`
- switched the nixpkgs input to use the `nixpkgs-unstable` branch instead of `nixos-unstable`, since this project doesn't need the additional tests added by the `nixos` variant.
- removed `x86_64-darwin` from supported systems due to nixpkgs no longer supporting it
- removed `rec` from packages definition in favour of using `self.packages.${pkgs.stdenv.hostPlatform.system}.csakura`, following best practices
- removed redundant makeFlags line (`CC=cc`), since `pkgs.stdenv.mkDerivation` already does this
- removed unnecessary `apps` output, which does nothing, as `nix run` already runs `pkgs.${system}.default` without requiring any extra code